### PR TITLE
Add Shopping List Sharing Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ An all-in-one platform for managing online shopping across multiple stores built
 
 ## Features
 - Create and manage shopping lists
-- Track orders across multiple stores
+- Share shopping lists with other users
+- Track orders across multiple stores 
 - Store shipping details securely
 - Manage payment methods
 - Store profile preferences
@@ -12,6 +13,14 @@ An all-in-one platform for managing online shopping across multiple stores built
 - Create and manage user profiles
 - Add/remove stores
 - Create/update shopping lists
+- Share shopping lists with other users
 - Track order status
-- Manage shipping addresses 
+- Manage shipping addresses
 - Set preferences
+
+## Shopping List Sharing
+Users can now share their shopping lists with other users while maintaining full control:
+- Share lists with specific users
+- Remove user access at any time
+- View shared lists separately
+- Original owner maintains full control


### PR DESCRIPTION
This PR introduces a new shopping list sharing feature that allows users to collaborate on shopping lists while maintaining proper access control.

### New Features
- Share shopping lists with specific users
- Unshare lists to revoke access
- Access control checks for list operations
- List ownership tracking
- Maximum of 10 shares per list

### Implementation Details
- Added shared-with field to ShoppingLists data structure
- New share-shopping-list and unshare-shopping-list functions
- Added can-access-list helper function for permission checks
- Updated tests to cover sharing functionality
- Added documentation in README

### Security Considerations
- Only list owners can share/unshare lists
- Proper access control checks on all list operations
- Prevention of duplicate shares
- List size limits enforced

### Benefits
- Enables collaborative shopping planning
- Helps families/roommates coordinate purchases
- Maintains security through proper access controls
- Improves user experience through list sharing